### PR TITLE
style: add gap between project title and upvote

### DIFF
--- a/src/components/layout/Project.tsx
+++ b/src/components/layout/Project.tsx
@@ -43,7 +43,7 @@ export default component$((props: { project: Project | null }) => {
       <div class="u-width-full-line" style="padding: var(--p-card-padding);">
         <div class="u-flex u-cross-center u-gap-8 u-main-space-between u-width-full-line">
           <div class="u-stretch u-flex-vertical u-gap-16">
-            <div class="u-flex u-main-space-between u-cross-center">
+            <div class="u-flex u-main-space-between u-cross-center u-gap-8">
               <Link href={`/projects/${project.$id}`}>
                 <p class="heading-level-4 c-trim" style="font-size: 1.3rem;">
                   {project.name}

--- a/src/components/layout/ProjectFeatured.tsx
+++ b/src/components/layout/ProjectFeatured.tsx
@@ -22,7 +22,7 @@ export default component$((props: { project: Project }) => {
         </div>
 
         <div class="u-flex u-flex-vertical u-stretch u-gap-8">
-          <div class="u-flex u-main-space-between u-cross-center">
+          <div class="u-flex u-main-space-between u-cross-center u-gap-8">
             <Link
               href={`/projects/${project.$id}`}
               class="heading-level-3 u-margin-block-start-12 c-trim"


### PR DESCRIPTION
## What does this PR do?

adds 8px gap between project title and upvote on the:
- `<Project />` component
- `<ProjectFeatured />` component

## Test Plan

Manual

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes